### PR TITLE
Support for invariant contribution ID 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,7 @@ APP_SERVER_METRICS = false
 APP_SERVER_LOGGING = false
 APP_FILE_LOGGING = false
 APP_DATABASE = postgresql://CREDENTIALS@bbk-database/bit_broker
+APP_SECRET = a-long-secret-string
 
 # --- bootstrap for the first ever (coordinator) user
 

--- a/database/V1.0__bit_broker.sql
+++ b/database/V1.0__bit_broker.sql
@@ -56,7 +56,7 @@ CREATE TABLE connector
     entity_id SERIAL NOT NULL REFERENCES entity (id) ON DELETE CASCADE,
     slug VARCHAR (32) UNIQUE NOT NULL,
     properties JSONB NOT NULL,
-    contribution_id CHAR(36) UNIQUE,
+    contribution_id CHAR(40) UNIQUE,
     contribution_key_id CHAR(36) UNIQUE NOT NULL,
     is_live BOOLEAN NOT NULL DEFAULT FALSE,
     session_id CHAR(36) UNIQUE,
@@ -77,7 +77,7 @@ CREATE INDEX idx_connector_session_id ON connector (session_id);
 CREATE TABLE catalog
 (
     id SERIAL PRIMARY KEY,
-    public_id CHAR(64) NOT NULL UNIQUE,
+    public_id CHAR(40) NOT NULL UNIQUE,
     connector_id SERIAL NOT NULL REFERENCES connector (id) ON DELETE CASCADE,
     vendor_id VARCHAR(256) NOT NULL,
     record JSONB NOT NULL,
@@ -98,7 +98,7 @@ CREATE TABLE operation
 (
     id SERIAL PRIMARY KEY,
     session_id CHAR(36) NOT NULL REFERENCES connector (session_id) ON DELETE CASCADE,
-    public_id CHAR(64) NOT NULL,
+    public_id CHAR(40) NOT NULL,
     action OPERATION_ACTIONS NOT NULL,
     record JSONB NOT NULL,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/services/lib/controller/session.js
+++ b/services/lib/controller/session.js
@@ -82,7 +82,7 @@ module.exports = class Session {
         let errors = [];
 
         errors = errors.concat(model.validate.id(cid));
-        errors = errors.concat(model.validate.id(sid));
+        errors = errors.concat(model.validate.guid(sid));
         errors = errors.concat(model.validate.action(action));
 
         if (action === CONST.ACTION.UPSERT) errors = errors.concat(model.validate.records_upsert(records));
@@ -132,7 +132,7 @@ module.exports = class Session {
         let errors = [];
 
         errors = errors.concat(model.validate.id(cid));
-        errors = errors.concat(model.validate.id(sid));
+        errors = errors.concat(model.validate.guid(sid));
         errors = errors.concat(model.validate.commit(commit));
 
         if (errors.length) {

--- a/services/lib/model/connector.js
+++ b/services/lib/model/connector.js
@@ -110,7 +110,7 @@ module.exports = class Connector {
 
         .then (token => {
             values.slug = slug;
-            values.contribution_id = Permit.CONTRIBUTION_ID;
+            values.contribution_id = Permit.contribution_id(this.entity.slug, values.slug);
             values.contribution_key_id = token.jti;
             values.entity_id = this.db.from('entity').select('id').where({ slug: this.entity.slug }).first(); // this will *not* execute here, but is compounded into the SQL below
 

--- a/services/lib/model/permit.js
+++ b/services/lib/model/permit.js
@@ -45,14 +45,14 @@ module.exports = class Permit {
 
     // --- generates a unique contribution id
 
-    static get CONTRIBUTION_ID() {
-        return crypto.randomUUID();
+    static contribution_id(entity_slug, connector_slug) {
+        return crypto.createHash('sha1').update(`${ entity_slug }:${ connector_slug }:${ process.env.APP_SECRET }`).digest('hex');
     }
 
     // --- generates a public key from a connector id and a vendor id
 
     static public_key(connector_id, vendor_id) {
-        return crypto.createHash('sha256').update(`${ connector_id }:${ vendor_id }`).digest('hex');
+        return crypto.createHash('sha1').update(`${ connector_id }:${ vendor_id }`).digest('hex');
     }
 
     // --- obtains an access token and a key_id from the auth-service

--- a/services/lib/model/validate.js
+++ b/services/lib/model/validate.js
@@ -34,7 +34,7 @@ const util = require('util');
 
 // --- scheme list
 
-const SCHEMES = [ 'id', 'slug', 'string', 'name', 'description', 'date', 'entity', 'connector', 'session', 'policy', 'user', 'userid', 'user_addendum', 'paging', 'records', 'timeseries' ]; // we name them here, rather than just iterate the directory
+const SCHEMES = [ 'id', 'guid', 'slug', 'string', 'name', 'description', 'date', 'entity', 'connector', 'session', 'policy', 'user', 'userid', 'user_addendum', 'paging', 'records', 'timeseries' ]; // we name them here, rather than just iterate the directory
 
 // --- validate class (exported)
 
@@ -99,6 +99,7 @@ module.exports = class Validate {
     action(item) { return this.scheme(item, 'session#/action', 'action'); }
     commit(item) { return this.scheme(item, 'session#/commit', 'commit'); }
     id(item) { return this.scheme(item, 'id', 'id'); }
+    guid(item) { return this.scheme(item, 'guid', 'id'); }  
     limit(item) {return this.scheme(item, 'paging#/limit', 'limit'); }
     mode(item) { return this.scheme(item, 'session#/mode', 'mode'); }
     name(item) { return this.scheme(item, 'name', 'name'); }

--- a/services/lib/model/validation/guid.json
+++ b/services/lib/model/validation/guid.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "bbk://guid",
+    "type": "string",
+    "pattern": "^[a-z0-9][a-z0-9-]+$",
+    "minLength": 36,
+    "maxLength": 36
+}

--- a/services/lib/model/validation/id.json
+++ b/services/lib/model/validation/id.json
@@ -2,7 +2,7 @@
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "bbk://id",
     "type": "string",
-    "pattern": "^[a-z0-9][a-z0-9-]+$",
-    "minLength": 36,
-    "maxLength": 36
+    "pattern": "^[a-z0-9]+$",
+    "minLength": 40,
+    "maxLength": 40
 }

--- a/tests/consumer.js
+++ b/tests/consumer.js
@@ -136,8 +136,8 @@ describe('Consumer Tests', function() {
 
         function entity_base(type, fetched, original) {
             expect(fetched.id).to.be.a('string');
-            expect(fetched.id).to.match(new RegExp(DATA.PUBLIC_ID.REGEX));
-            expect(fetched.id.length).to.be.eq(DATA.PUBLIC_ID.SIZE);
+            expect(fetched.id).to.match(new RegExp(DATA.ID.REGEX));
+            expect(fetched.id.length).to.be.eq(DATA.ID.SIZE);
             expect(fetched.url).to.be.eq(URLs.consumer_entity(type, fetched.id));
             expect(fetched.type).to.be.eq(type);
             expect(fetched.name).to.be.eq(original.name);

--- a/tests/contributor.js
+++ b/tests/contributor.js
@@ -187,13 +187,13 @@ describe('Contributor Tests', function() {
         });
 
         it('cannot post data with an unknown session id', () => {
-            return Crud.unauthorized(URLs.session_action(session.cid, DATA.ID.UNKNOWN), [], chakram.post);
+            return Crud.unauthorized(URLs.session_action(session.cid, DATA.GUID.UNKNOWN), [], chakram.post);
         });
 
         it('cannot post data with various invalid id and actions', () => {
             return Promise.resolve()
             .then (() => Crud.bad_request(URLs.session_action(DATA.ID.UNKNOWN + 'x', session.sid), [{ id: DATA.ERRORS.MAX }], [], chakram.post))
-            .then (() => Crud.bad_request(URLs.session_action(session.cid, DATA.ID.UNKNOWN + 'x'), [{ id: DATA.ERRORS.MAX }], [], chakram.post))
+            .then (() => Crud.bad_request(URLs.session_action(session.cid, DATA.GUID.UNKNOWN + 'x'), [{ id: DATA.ERRORS.MAX }], [], chakram.post))
             .then (() => Crud.bad_request(URLs.session_action(session.cid, session.sid, DATA.slug()), [{ action: DATA.ERRORS.ENUM }], [], chakram.post));
         });
 
@@ -202,15 +202,15 @@ describe('Contributor Tests', function() {
         });
 
         it('cannot close a session with an unknown session id', () => {
-            return Crud.unauthorized(URLs.session_close(session.cid, DATA.ID.UNKNOWN));
+            return Crud.unauthorized(URLs.session_close(session.cid, DATA.GUID.UNKNOWN));
         });
 
         it('cannot close a session with various invalid ids and commits', () => {
             return Promise.resolve()
             .then (() => Crud.bad_request(URLs.session_close(DATA.ID.UNKNOWN + 'x', session.sid), [{ id: DATA.ERRORS.MAX }]))
             .then (() => Crud.bad_request(URLs.session_close(DATA.ID.UNKNOWN + 'X', session.sid), [{ id: DATA.ERRORS.FORMAT }]))
-            .then (() => Crud.bad_request(URLs.session_close(session.cid, DATA.ID.UNKNOWN + 'x'), [{ id: DATA.ERRORS.MAX }]))
-            .then (() => Crud.bad_request(URLs.session_close(session.cid, DATA.ID.UNKNOWN + 'X'), [{ id: DATA.ERRORS.FORMAT }]))
+            .then (() => Crud.bad_request(URLs.session_close(session.cid, DATA.GUID.UNKNOWN + 'x'), [{ id: DATA.ERRORS.MAX }]))
+            .then (() => Crud.bad_request(URLs.session_close(session.cid, DATA.GUID.UNKNOWN + 'X'), [{ id: DATA.ERRORS.FORMAT }]))
             .then (() => Crud.bad_request(URLs.rest('connector', session.cid, 'session', session.sid, 'close', DATA.slug()), [{ commit: DATA.ERRORS.ENUM }]));
         });
 

--- a/tests/coordinator.js
+++ b/tests/coordinator.js
@@ -496,7 +496,7 @@ describe('Coordinator Service Tests', function() {
             return Crud.add(connector1, values1, connector1, body => {
                 expect(body).to.be.an('object');
                 expect(body.id).to.be.a('string');
-                expect(body.id).to.match(new RegExp(DATA.ID.REGEX));
+                expect(body.id).to.match(new RegExp(DATA.GUID.REGEX));
                 expect(body.token).to.be.a('string');
                 expect(body.token).to.match(new RegExp(DATA.KEY.REGEX));
             })
@@ -521,7 +521,7 @@ describe('Coordinator Service Tests', function() {
             return Crud.add(connector2, values2, connector2, body => {
                 expect(body).to.be.an('object');
                 expect(body.id).to.be.a('string');
-                expect(body.id).to.match(new RegExp(DATA.ID.REGEX));
+                expect(body.id).to.match(new RegExp(DATA.GUID.REGEX));
                 expect(body.token).to.be.a('string');
                 expect(body.token).to.match(new RegExp(DATA.KEY.REGEX));
             })

--- a/tests/lib/data.js
+++ b/tests/lib/data.js
@@ -161,15 +161,16 @@ const DATA = {
         REGEX: "^v\\d+$",
     },
 
-    ID: { // uuidv4
+    GUID: { // uuidv4 - i.e. session_ids
         SIZE: 36,
         REGEX: "^[a-z0-9][a-z0-9-]+$",
         UNKNOWN: '6b50b0c0-7df3-40d5-8a5f-51cd0141a084',
     },
 
-    PUBLIC_ID: { // sha256
-        SIZE: 64,
+    ID: { // sha1 - i.e. contribution_ids and public_ids
+        SIZE: 40,
         REGEX: "^[a-z0-9]+$",
+        UNKNOWN: 'aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d',
     },
 
     KEY: { // jwt
@@ -233,7 +234,7 @@ const DATA = {
             value: "^\\d+$"
         }
     },
-    
+
     PROSE: 'lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod tempor incididunt ut labore et dolore magna aliqua ut enim ad minim veniam quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur excepteur sint occaecat cupidatat non proident sunt in culpa qui officia deserunt mollit anim id est laborum',
 
     POLICY: {

--- a/tests/lib/session.js
+++ b/tests/lib/session.js
@@ -54,8 +54,8 @@ module.exports = class Session {
 
             .then(response => {
                 expect(response.body).to.be.a('string');
-                expect(response.body).to.match(new RegExp(DATA.ID.REGEX));
-                expect(response.body.length).to.be.eq(DATA.ID.SIZE);
+                expect(response.body).to.match(new RegExp(DATA.GUID.REGEX));
+                expect(response.body.length).to.be.eq(DATA.GUID.SIZE);
                 expect(response).to.have.status(HTTP.OK);
                 return response.body;
             })
@@ -86,8 +86,8 @@ module.exports = class Session {
                     for (let j = start; j < end; j++) {
                         let key = action === 'upsert' ? data[j].id : data[j];
                         expect(response.body[key]).to.a('string');
-                        expect(response.body[key]).to.match(new RegExp(DATA.PUBLIC_ID.REGEX));
-                        expect(response.body[key].length).to.be.eq(DATA.PUBLIC_ID.SIZE);
+                        expect(response.body[key]).to.match(new RegExp(DATA.ID.REGEX));
+                        expect(response.body[key].length).to.be.eq(DATA.ID.SIZE);
                     }
                     expect(response).to.have.status(HTTP.OK);
                     return chakram.wait();


### PR DESCRIPTION
Fixes issue #303. Contribution IDs are now the same for the same entity slug + connector slug combination