### PR TITLE
Addresses issue #6 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,8 @@ CONSUMER_USER = bbk_consumer:bbk_consumer_pwd
 # --- ancillary services: deploy for all services
 
 POLICY_CACHE = redis://bbk-policy-cache:6379
+POLICY_CACHE_PASSWORD = ""
+POLICY_CACHE_DB = "0"
 AUTH_SERVICE = http://bbk-auth-service:8080/api/v1
 RATE_SERVICE = http://bbk-rate-limit:4000/api/v1
 

--- a/development/docker-compose/docker-compose.yml
+++ b/development/docker-compose/docker-compose.yml
@@ -27,6 +27,7 @@ networks:
 volumes:
   dbdata:
 
+
 services:
   # --- coordinator service
   bbk-coordinator:
@@ -45,7 +46,11 @@ services:
     ports:
       - 8001:8001
     healthcheck:
-      test: ["CMD-SHELL", "wget http://localhost:8001/v1 -q --spider"]
+      test:
+        [
+          "CMD-SHELL",
+          "wget http://localhost:8001/v1 -q --spider"
+        ]
       interval: 4s
       timeout: 4s
       retries: 4
@@ -64,7 +69,11 @@ services:
     ports:
       - 8002:8002
     healthcheck:
-      test: ["CMD-SHELL", "wget http://localhost:8002/v1 -q --spider"]
+      test:
+        [
+          "CMD-SHELL",
+          "wget http://localhost:8002/v1 -q --spider"
+        ]
       interval: 4s
       timeout: 4s
       retries: 4
@@ -83,7 +92,11 @@ services:
     ports:
       - 8003:8003
     healthcheck:
-      test: ["CMD-SHELL", "wget http://localhost:8003/v1 -q --spider"]
+      test:
+        [
+          "CMD-SHELL",
+          "wget http://localhost:8003/v1 -q --spider"
+        ]
       interval: 4s
       timeout: 4s
       retries: 4
@@ -95,7 +108,7 @@ services:
     container_name: bbk-database
     volumes:
       - dbdata:/var/lib/postgresql/data
-      - ../../database:/docker-entrypoint-initdb.d 
+      - ../../database:/docker-entrypoint-initdb.d
     environment:
       POSTGRES_PASSWORD: "bitbr0ker"
     ports:
@@ -104,7 +117,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          'psql -U postgres -lqt | cut -d \| -f 1 | grep -qw bit_broker',
+          'psql -U postgres -lqt | cut -d \| -f 1 | grep -qw bit_broker'
         ]
       interval: 4s
       timeout: 4s
@@ -122,7 +135,7 @@ services:
       - 7000:7000
     env_file: ../../.env
     healthcheck:
-      test: ["CMD-SHELL", "ls"]
+      test: [ "CMD-SHELL", "ls" ]
       interval: 4s
       timeout: 4s
       retries: 4
@@ -138,7 +151,11 @@ services:
       - 8080:8080
     env_file: ../../.env
     healthcheck:
-      test: ["CMD-SHELL", "wget http://localhost:8080/api/v1 -q --spider"]
+      test:
+        [
+          "CMD-SHELL",
+          "wget http://localhost:8080/api/v1 -q --spider"
+        ]
       interval: 4s
       timeout: 4s
       retries: 4
@@ -149,8 +166,10 @@ services:
     container_name: bbk-policy-cache
     ports:
       - 6379:6379
+    # uncomment / update line below if you have set POLICY_CACHE_PASSWORD in .env
+    # command: redis-server --requirepass POLICY_CACHE_PASSWORD
     healthcheck:
-      test: ["CMD-SHELL", "redis-cli ping"]
+      test: [ "CMD-SHELL", "redis-cli ping" ]
       interval: 4s
       timeout: 4s
       retries: 4

--- a/services/lib/model/index.js
+++ b/services/lib/model/index.js
@@ -39,7 +39,7 @@ const log = require('../logger.js').Logger;
 // --- running contexts
 
 var db = new Knex({ client: 'pg', connection: process.env.APP_DATABASE }); // TODO: should we fix the client version here?
-var redis = new Redis(process.env.POLICY_CACHE, { commandTimeout: CONST.REDIS.TIMEOUT });
+var redis = new Redis(`${process.env.POLICY_CACHE}?db=${process.env.POLICY_CACHE_DB}&password=${process.env.POLICY_CACHE_PASSWORD}`, { commandTimeout: CONST.REDIS.TIMEOUT });
 
 // --- redis event logging
 


### PR DESCRIPTION
Can now configure BBK services to use a password protected redis service via .env vars:

POLICY_CACHE_PASSWORD = ""
POLICY_CACHE_DB = "0"

Defaults to 'open' i.e. empty password as above, configuration will be needed to add to deployment charts to deploy with password protection enabled.

To test in docker-compose:

* set .env POLICY_CACHE_PASSWORD to a non empty value
* update docker-compose.yml line 170 to reflect the value chosen for POLICY_CACHE_PASSWORD

* deploy BBK with docker-compose
* run test suite - this should run clear

to access the redis instance via the redis cli you will need to provide the password e.g. by running 
```docker run -it --rm -e REDISCLI_AUTH=<redis password> redis redis-cli -h <redis host> -p 6379```

without the password, redis-cli will connect but commands will return '(error) NOAUTH Authentication required.'

